### PR TITLE
Bump marked and mocha dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# node-copytext [![Build Status](https://travis-ci.org/rdmurphy/node-copytext.svg?branch=master)](https://travis-ci.org/rdmurphy/node-copytext)
+# node-copytext [![Build Status](https://travis-ci.org/rdmurphy/node-copytext.svg?branch=master)](https://travis-ci.org/rdmurphy/node-copytext) [![Dependency Status](https://david-dm.org/rdmurphy/node-copytext.svg)](https://david-dm.org/rdmurphy/node-copytext)
 
 A node library for accessing a XLSX spreadsheet as a JavaScript object. (Markdown batteries included!) Inspired by the NPR visuals team's [copytext](https://github.com/nprapps/copytext) library for Python. Works great coupled with group-edited Google Spreadsheet exported as a XLSX file.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "copytext",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "description": "A module for accessing a XLSX spreadsheet as a JavaScript object. (Markdown batteries included.)",
   "main": "index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -31,10 +31,10 @@
     "node": ">=0.10.0"
   },
   "dependencies": {
-    "marked": "^0.3.3",
+    "marked": "^0.3.5",
     "xlsx": "^0.8.0"
   },
   "devDependencies": {
-    "mocha": "^2.2.4"
+    "mocha": "^2.2.5"
   }
 }


### PR DESCRIPTION
[The pinned version of marked has had a security issue for a while now](https://nodesecurity.io/advisories/marked_redos) — this commit finally fixes that.
